### PR TITLE
Integrate with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: clojure
+script: lein2 silent test
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# aufi
+# aufi [![Build Status](https://travis-ci.org/stylefruits/aufi.svg?branch=master)](https://travis-ci.org/stylefruits/aufi)
 
 __aufi__ is a service for image upload, retrieval and resizing.
 

--- a/project.clj
+++ b/project.clj
@@ -46,4 +46,6 @@
                    ^:replace
                    ["-Djava.awt.headless=true"
                     "-Dlogback.configurationFile=resources/logback-dev.xml"]}}
-  :aliases {"silent" ["with-profile" "+silent"]})
+  :aliases {"silent" ["with-profile" "+silent"]}
+  :test-selectors {:default (complement :with-aws-credentials)
+                   :all     (constantly true)})

--- a/test/aufi/system/config_test.clj
+++ b/test/aufi/system/config_test.clj
@@ -4,7 +4,7 @@
             [peripheral.core :refer [with-start]])
   (:import [java.io File]))
 
-(deftest t-config
+(deftest ^:with-aws-credentials t-config
   (let [f (File/createTempFile "config" ".edn")]
     (try
       (testing "complete configuration."


### PR DESCRIPTION
This adds selectors to exclude tests requiring AWS credentials and adds a `.travis.yml`.
