### PR TITLE
Fix Race Condition in Saturation Tests

### DIFF
--- a/test/aufi/core_test.clj
+++ b/test/aufi/core_test.clj
@@ -84,8 +84,8 @@
   [& [put-lock retrieve-lock]]
   (make-aufi
     {:image-store (test/make-locking-image-store
-                    (or put-lock (test/make-lock))
-                    (or retrieve-lock (test/make-lock)))
+                    (or put-lock (test/lock))
+                    (or retrieve-lock (test/lock)))
      :config {:httpd httpd-opts}}))
 
 ;; ## Tests
@@ -178,11 +178,6 @@
 
 ;; ## Saturation Tests
 
-(defn- lock!
-  []
-  (doto (test/make-lock)
-    (.lock)))
-
 (defn- bombard!
   [n statuses request-fn]
   (doall
@@ -192,9 +187,9 @@
              (:status)
              (swap! statuses conj))))))
 
-(defn- unlock!
+(defn- wait!
   [lock bombardment]
-  (.unlock lock)
+  (test/release! lock)
   (doseq [fut bombardment]
     @fut)
   true)
@@ -209,21 +204,21 @@
         bombardment (bombard! bombard-count statuses saturate-fn)]
     (Thread/sleep 100)
     (is (= unsaturate-success-status (:status (unsaturate-fn))))
-    (is (unlock! lock bombardment))
+    (is (wait! lock bombardment))
     (let [fq (frequencies @statuses)]
       (is (= max-requests (get fq saturate-success-status)))
       (is (= expected-failures (get fq 503))))))
 
 (deftest t-saturation
   (testing "POST saturation does not influence GET requests."
-    (let [lock (lock!)]
-      (with-start [aufi (locking-test-system lock)]
+    (let [lock (test/lock! threads)]
+      (with-start [aufi (locking-test-system lock nil)]
         (test-saturation!
           test-post! 201
           test-get!  404
           lock))))
   (testing "GET saturation does not influence POST requests."
-    (let [lock (lock!)]
+    (let [lock (test/lock! threads)]
       (with-start [aufi (locking-test-system nil lock)]
         (test-saturation!
           test-get!  404
@@ -237,8 +232,8 @@
                           "&upload-capacity=" %)
                      (get! "/_status")
                      :status)
-        put-lock (lock!)
-        retrieve-lock (lock!)]
+        put-lock (test/lock! threads)
+        retrieve-lock (test/lock! threads)]
     (testing "health check based on thresholds."
       (with-start [aufi (locking-test-system put-lock retrieve-lock)]
         (is (= 200 (check! 0.5)))
@@ -247,12 +242,12 @@
             (Thread/sleep 100)
             (is (= 503 (check! 0.5)))
             (is (= 200 (check! 0.0)))
-            (unlock! retrieve-lock bombardment)
+            (wait! retrieve-lock bombardment)
             (is (= 200 (check! 0.5)))))
         (testing "POST saturation."
           (let [bombardment (bombard!  max-requests (atom []) test-post!)]
             (Thread/sleep 100)
             (is (= 503 (check! 0.5)))
             (is (= 200 (check! 0.0)))
-            (unlock! put-lock bombardment)
+            (wait! put-lock bombardment)
             (is (= 200 (check! 0.5)))))))))

--- a/test/aufi/test.clj
+++ b/test/aufi/test.clj
@@ -66,29 +66,44 @@
       (swap! log-atom (fnil conj []) [:resize type width height])
       image)))
 
+;; ## Lock Helpers
+
+(defn lock
+  []
+  {:lock (ReentrantLock.)})
+
+(defn lock!
+  [threads]
+  {:lock
+   (doto (ReentrantLock.)
+     (.lock))})
+
+(defn acquire!
+  [{:keys [lock]}]
+  (.lock ^Lock lock))
+
+(defn release!
+  [{:keys [lock]}]
+  (.unlock ^Lock lock))
+
 ;; ## Locking Image Store
 
-(defrecord LockingImageStore [^Lock put-lock ^Lock retrieve-lock internal-store]
+(defrecord LockingImageStore [put-lock retrieve-lock internal-store]
   protocols/ImageStore
   (check-health! [_]
     true)
   (put-image! [_ data]
-    (.lock put-lock)
+    (acquire! put-lock)
     (try
       (protocols/put-image! internal-store data)
       (finally
-        (.unlock put-lock))))
+        (release! put-lock))))
   (retrieve-image! [_ id]
-    (.lock retrieve-lock)
+    (acquire! retrieve-lock)
     (try
       (protocols/retrieve-image! internal-store id)
       (finally
-        (.unlock retrieve-lock)))))
-
-(defn make-lock
-  ^java.util.concurrent.locks.ReentrantLock
-  []
-  (ReentrantLock.))
+        (release! retrieve-lock)))))
 
 (defn make-locking-image-store
   [put-lock retrieve-lock]


### PR DESCRIPTION
This fixes a race condition in the saturation tests where it was possible for the test code to run before the server was fully congested.

The original code used to sleep for 100ms, the adjusted logic uses a `CountDownLatch` (with counter set to available threads and decremented once a request comes in) to reliably detect the congestion.
