### PR TITLE
Remove Connection Pool From Tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,8 @@
                       ^:replace
                       ["-Djava.awt.headless=true"
                        "-Dlogback.configurationFile=resources/logback-silent.xml"]}
-             :dev {:dependencies [[criterium "0.4.4"]]
+             :dev {:dependencies [[criterium "0.4.4"]
+                                  [clj-http "3.0.1"]]
                    :jvm-opts
                    ^:replace
                    ["-Djava.awt.headless=true"


### PR DESCRIPTION
Since the connection pool was a global object there might be some unpredictable interaction between different testcases or even test runs.

This might be the cause for some of the failing saturation tests [1] where more successful requests are observed than expected – which can be the result of the connection pool not offering a connection for a expected-to-fail HTTP request quickly enough, i.e. before the congestion has disappeared.

Additionally, this makes sure that – if we're not interested in the response `:body` for a test – we're closing its `InputStream`.

[1] https://travis-ci.org/stylefruits/aufi/jobs/154383745
